### PR TITLE
refactor: full cleanup — dead code, audio pipeline, helpers, ino translation

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,3 +50,22 @@ DAMPING_FACTOR      = float(os.environ.get("DAMPING_FACTOR",    "0.6"))
 # ---------------------------------------------------------------------------
 OFFSET_Y = float(os.environ.get("OFFSET_Y", "-10.0"))
 OFFSET_Z = float(os.environ.get("OFFSET_Z",  "0.0"))
+
+# ---------------------------------------------------------------------------
+# Audio processing
+# ---------------------------------------------------------------------------
+AUDIO_SILENCE_THRESHOLD = float(os.environ.get("AUDIO_SILENCE_THRESHOLD", "0.01"))
+AUDIO_SILENCE_MARGIN    = float(os.environ.get("AUDIO_SILENCE_MARGIN",    "0.3"))   # seconds
+AUDIO_MIN_DURATION      = float(os.environ.get("AUDIO_MIN_DURATION",      "0.5"))   # seconds
+AUDIO_MAX_DURATION      = float(os.environ.get("AUDIO_MAX_DURATION",      "15.0"))  # seconds
+
+# ---------------------------------------------------------------------------
+# Default motion increment for fuzzy directional commands (no explicit distance)
+# ---------------------------------------------------------------------------
+DEFAULT_MOVE_MM = float(os.environ.get("DEFAULT_MOVE_MM", "50.0"))
+
+# ---------------------------------------------------------------------------
+# Gesture animation (nod / shake_head)
+# ---------------------------------------------------------------------------
+GESTURE_AMPLITUDE = float(os.environ.get("GESTURE_AMPLITUDE", "30.0"))  # mm
+GESTURE_CYCLES    = int(os.environ.get("GESTURE_CYCLES",    "3"))

--- a/main.ino
+++ b/main.ino
@@ -1,45 +1,45 @@
 /*
- * ESP32 原生硬件 PWM 控制程序 (适配 Core 3.x 版本)
- * 解决 'ledcSetup' was not declared 报错问题
+ * ESP32 native hardware PWM servo controller (ESP32 Arduino Core 3.x)
+ * Uses the updated ledcAttach/ledcWrite API (replaces deprecated ledcSetup).
  */
 
-// --- 1. 引脚定义 ---
-const int PIN_X = 14; 
-const int PIN_Y = 4;  
-const int PIN_Z = 5;  
-const int PIN_B = 18; 
-const int PIN_G = 23; 
+// --- 1. Pin assignments ---
+const int PIN_X = 14;  // X-axis servo
+const int PIN_Y = 4;   // Y-axis servo
+const int PIN_Z = 5;   // Z-axis servo
+const int PIN_B = 18;  // Base rotation servo
+const int PIN_G = 23;  // Gripper servo
 
-// --- 2. PWM 参数 (舵机标准) ---
-const int freq = 50;           // 频率 50Hz (周期 20ms)
-const int resolution = 12;     // 分辨率 12位 (数值范围 0-4095)
+// --- 2. PWM parameters (standard servo) ---
+const int freq = 50;        // 50 Hz (20 ms period)
+const int resolution = 12;  // 12-bit resolution (0–4095)
 
-// 舵机角度对应的占空比数值 (12位分辨率)
-// 0.5ms (0度)   -> 约 102
-// 1.5ms (90度)  -> 约 307
-// 2.5ms (180度) -> 约 512
+// Duty-cycle values for servo angles (12-bit, 50 Hz):
+//   0.5 ms (  0°) → ~102
+//   1.5 ms ( 90°) → ~307
+//   2.5 ms (180°) → ~512
 
 void setup() {
   Serial.begin(115200);
   delay(1000);
 
-  Serial.println("\n--- 使用 ESP32 Core 3.x LEDC 驱动初始化 ---");
+  Serial.println("\n--- ESP32 Core 3.x LEDC driver initializing ---");
 
-  // 在新版 Core 中，直接使用 ledcAttach(引脚, 频率, 分辨率)
+  // Core 3.x API: ledcAttach(pin, frequency, resolution)
   ledcAttach(PIN_X, freq, resolution);
   ledcAttach(PIN_Y, freq, resolution);
   ledcAttach(PIN_Z, freq, resolution);
   ledcAttach(PIN_B, freq, resolution);
   ledcAttach(PIN_G, freq, resolution);
 
-  // 初始归中
+  // Center all servos at startup
   writeAngle(PIN_X, 90); delay(500);
   writeAngle(PIN_Y, 90); delay(500);
   writeAngle(PIN_Z, 90); delay(500);
   writeAngle(PIN_B, 90); delay(500);
   writeAngle(PIN_G, 90); delay(500);
 
-  Serial.println("--- 5轴硬件 PWM 初始化完成 ---");
+  Serial.println("--- 5-axis hardware PWM ready ---");
 }
 
 void loop() {
@@ -47,42 +47,39 @@ void loop() {
     String cmd = Serial.readStringUntil('\n');
     cmd.trim();
 
-    // 根据指令解析并控制
-    if (cmd.startsWith("Servo_ArmX")) writeAngle(PIN_X, extractAngle(cmd, "Servo_ArmX"));
-    else if (cmd.startsWith("Servo_ArmY")) writeAngle(PIN_Y, extractAngle(cmd, "Servo_ArmY"));
-    else if (cmd.startsWith("Servo_ArmZ")) writeAngle(PIN_Z, extractAngle(cmd, "Servo_ArmZ"));
-    else if (cmd.startsWith("Servo_ArmB")) writeAngle(PIN_B, extractAngle(cmd, "Servo_ArmB"));
+    if      (cmd.startsWith("Servo_ArmX"))    writeAngle(PIN_X, extractAngle(cmd, "Servo_ArmX"));
+    else if (cmd.startsWith("Servo_ArmY"))    writeAngle(PIN_Y, extractAngle(cmd, "Servo_ArmY"));
+    else if (cmd.startsWith("Servo_ArmZ"))    writeAngle(PIN_Z, extractAngle(cmd, "Servo_ArmZ"));
+    else if (cmd.startsWith("Servo_ArmB"))    writeAngle(PIN_B, extractAngle(cmd, "Servo_ArmB"));
     else if (cmd.startsWith("Servo_Gripper")) {
       int a = extractAngle(cmd, "Servo_Gripper");
       if (a != -1) {
         writeAngle(PIN_G, a);
-        Serial.print("夹爪已转动至: "); Serial.println(a);
+        Serial.print("Gripper moved to: "); Serial.println(a);
       }
     }
   }
 }
 
 /**
- * 核心控制函数
- * pin: 控制的引脚号
- * angle: 目标角度 (0-180)
+ * Write a target angle to a servo pin.
+ * pin  : GPIO pin number
+ * angle: target angle in degrees (0–180, clamped)
  */
 void writeAngle(int pin, int angle) {
-  if (angle < 0) angle = 0;
+  if (angle < 0)   angle = 0;
   if (angle > 180) angle = 180;
-  
-  // 线性映射计算占空比
-  // 0度 = 102, 180度 = 512
+
+  // Linear map: 0° → duty 102, 180° → duty 512
   int duty = (angle * (512 - 102) / 180) + 102;
-  
-  // 在新版 Core 中，ledcWrite 直接接收引脚号和数值
+
+  // Core 3.x API: ledcWrite takes pin number directly
   ledcWrite(pin, duty);
 }
 
-// 提取命令中的数字
+/** Extract the numeric argument after a known command prefix. Returns -1 on failure. */
 int extractAngle(String cmd, String prefix) {
-  int prefixLen = prefix.length();
-  String valPart = cmd.substring(prefixLen);
+  String valPart = cmd.substring(prefix.length());
   if (valPart.length() > 0) return valPart.toInt();
   return -1;
 }

--- a/whisper_main.py
+++ b/whisper_main.py
@@ -1,7 +1,10 @@
+import re
+
 import numpy as np
 import scipy.io.wavfile as wav
-import sounddevice as sd
 from faster_whisper import WhisperModel
+
+import config
 
 
 class RobotEar:
@@ -11,17 +14,85 @@ class RobotEar:
         self.model = WhisperModel(model_size, device="cuda", compute_type="float16")
         self.fs = 16000
 
-    def get_text(self, audio_data):
-        """Transcribe audio frames to text.
+    def get_text(self, audio_frames):
+        """Transcribe audio frames to text with silence trimming and duration guards.
 
         Args:
-            audio_data: list of numpy arrays captured from sounddevice InputStream.
+            audio_frames: list of numpy arrays captured from sounddevice InputStream.
 
         Returns:
-            Transcribed string (stripped).
+            Transcribed string (stripped), or "" if audio is empty/too short/silent.
         """
+        if not audio_frames:
+            return ""
+
+        audio_data = np.concatenate(audio_frames, axis=0)
+        audio_flat = audio_data.flatten()
+
+        # Trim leading/trailing silence to reduce Whisper hallucinations
+        nonzero = np.where(np.abs(audio_flat) > config.AUDIO_SILENCE_THRESHOLD)[0]
+        if len(nonzero) == 0:
+            print("[Audio] No speech detected")
+            return ""
+
+        margin = int(self.fs * config.AUDIO_SILENCE_MARGIN)
+        start = max(0, nonzero[0] - margin)
+        end = min(len(audio_flat), nonzero[-1] + margin)
+        audio_trimmed = audio_flat[start:end]
+
+        duration = len(audio_trimmed) / self.fs
+        if duration < config.AUDIO_MIN_DURATION:
+            print(f"[Audio] Too short ({duration:.1f}s), skipping")
+            return ""
+        if duration > config.AUDIO_MAX_DURATION:
+            print(f"[Audio] Too long ({duration:.1f}s), truncating to {config.AUDIO_MAX_DURATION:.0f}s")
+            audio_trimmed = audio_trimmed[:int(self.fs * config.AUDIO_MAX_DURATION)]
+
         temp_file = "temp_voice.wav"
-        audio_np = np.concatenate(audio_data, axis=0)
-        wav.write(temp_file, self.fs, (audio_np * 32767).astype(np.int16))
-        segments, _ = self.model.transcribe(temp_file, beam_size=5, language="zh")
-        return "".join(s.text for s in segments).strip()
+        wav.write(temp_file, self.fs, (audio_trimmed * 32767).astype(np.int16))
+
+        segments, _ = self.model.transcribe(
+            temp_file,
+            beam_size=5,
+            language="zh",
+            no_speech_threshold=0.5,
+            condition_on_previous_text=False,  # prevents "向右向右向右..." hallucination loop
+            # i18n: domain hint for Whisper — Chinese robot command vocabulary
+            initial_prompt="机械臂控制指令：抓取,抬起,放下,松开,复位,点头,摇头,削笔刀,盒子,零件,瓶子,厘米,毫米,向上,向下,向左,向右,向前,向后"
+        )
+
+        text = "".join(s.text for s in segments)
+        return self._fix_recognition(text.strip())
+
+    def _fix_recognition(self, text):
+        """Post-process ASR output: punctuation removal, homophone correction, dedup."""
+        if not text:
+            return text
+
+        text = re.sub(r'[,，。！？!?、;；]', '', text)
+
+        # i18n: Chinese homophone correction table (Whisper mishearings → correct words)
+        replacements = {
+            '小笔刀': '削笔刀', '消笔刀': '削笔刀', '销笔刀': '削笔刀',
+            '零米': '厘米', '里米': '厘米', '黎米': '厘米', '离米': '厘米',
+            '公分': '厘米', '利米': '厘米',
+            '电头': '点头', '点投': '点头', '店头': '点头', '垫头': '点头',
+            '药头': '摇头', '要头': '摇头', '右头': '摇头', '咬头': '摇头', '摇土': '摇头',
+        }
+        for wrong, right in replacements.items():
+            text = text.replace(wrong, right)
+
+        # Detect and strip repeated-phrase hallucinations like "向右向右向右..."
+        dedup_match = re.match(r'^(.{2,8}?)(.{2,8}?)\2{2,}', text)
+        if dedup_match:
+            text = dedup_match.group(1)
+            print(f"[Dedup] Repeated hallucination stripped, kept: {text}")
+
+        if len(text) > 30:
+            words = re.findall(r'向[上下左右前后]', text)
+            if len(words) > 3:
+                first_match = re.search(r'(.*?向[上下左右前后].*?\d+.*?厘米)', text)
+                text = first_match.group(1) if first_match else text[:20]
+                print(f"[Dedup] Overlong text truncated to: {text}")
+
+        return text.strip()


### PR DESCRIPTION
## Summary

Full codebase refactor: dead code removal, architectural cleanup, English-only enforcement.

- **#8** `arm_main.py`: remove dead `plt` import (~100ms startup), delete `path_history` memory leak + redundant FK call in `_send_and_audit`, fix `OFFSET_Y/Z` init to read from config directly, remove redundant `set_correction`/`set_damping_params` calls
- **#9** Audio pipeline: move full pipeline (silence trim, duration guards, WAV write, Whisper options, post-processing) into `RobotEar.get_text()`; `_fix_recognition()` moved to `RobotEar`; `get_audio_text()` becomes a one-liner; remove `scipy.io.wavfile` from `voice_main.py`; add audio constants to `config.py`
- **#10** Extract `AutoGraspSystem._approach_and_grasp()` (deduplicates `execute_pick`/`execute_lift`), extract `RobotApp._oscillate()` (deduplicates `nod`/`shake_head`); move `DEFAULT_MOVE_MM`, `GESTURE_AMPLITUDE`, `GESTURE_CYCLES` to `config.py`
- **#11** Translate all Chinese text in `main.ino` to English (comments, `Serial.println`, inline notes)

## Test plan

- [ ] `python3 -c "import ast; [ast.parse(open(f).read()) for f in ['config.py','arm_main.py','whisper_main.py','voice_main.py']]"` — no syntax errors
- [ ] `python3 arm_main.py` — simulation mode runs motion sequence without error
- [ ] `python3 -c "from whisper_main import RobotEar; help(RobotEar.get_text)"` — signature matches call site in `voice_main.py`
- [ ] Confirm `config.OFFSET_Y` is applied on `RobotArmUltimate()` construction without any `set_correction` call